### PR TITLE
Use NGL renderer instead of Vulkan to avoid crash when loading video

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -20,6 +20,9 @@ apps:
     command: usr/bin/fractal
     common-id: org.gnome.Fractal
     desktop: usr/share/applications/org.gnome.Fractal.desktop
+    environment:
+      # avoid crash when loading video if using vulkan
+      GSK_RENDERER: ngl
     plugs:
       - network
       - network-status


### PR DESCRIPTION
fractal is crashing with SIGSEGV in `libvulkan_radeon.so` when loading a video message.
it may or may not be working on other GPU drivers.

Note that the libgtk-4-1 in noble would already use `ngl`, but gnome-sdk is building a newer version from source which defaults to `vulkan`.